### PR TITLE
Set key type to rsa

### DIFF
--- a/lib/capistrano/one_time_key.rb
+++ b/lib/capistrano/one_time_key.rb
@@ -18,7 +18,7 @@ module Capistrano
     end
 
     def self.generate_private_key!
-      `ssh-keygen -m PEM -f #{temporary_ssh_private_key_path} -N "" -C "#{comment}"`
+      `ssh-keygen -f #{temporary_ssh_private_key_path} -N "" -C "#{comment}"`
       return temporary_ssh_private_key_path
     end
 


### PR DESCRIPTION
I believe do to a a recent update to openssh and/or in the latest macos update (I'm on `Version 26.6 (25G72)`) I get the following error when deploying:

```
Saving key "/var/folders/ld/b_hg3g4563z0l7njfj07j8ww0000gp/T/d20260730-59132-wwsdzz/capistrano_key" failed: error in libcrypto
(Backtrace restricted to imported tasks)
cap aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - /var/folders/ld/b_hg3g4563z0l7njfj07j8ww0000gp/T/d20260730-59132-wwsdzz/capistrano_key.pub (Errno::ENOENT)

Tasks: TOP => otk:generate
(See full trace by running task with --trace)
```

I verified this fix (remove the `-m PEM`) resolved the issue in a monkeypatch, but we probably don't want to sprinkle that everywhere.
